### PR TITLE
Replace stop statements with call to terminate() subroutine

### DIFF
--- a/f90_gui/src/f90_gui.F90
+++ b/f90_gui/src/f90_gui.F90
@@ -153,6 +153,7 @@ module f90_gui
 !
 
   use c_types
+  use f90_util
 
   implicit none
   public
@@ -695,7 +696,7 @@ contains
     if(present(expander))then
        if(expander)c_expand=1
        if(expander.and.(.not.present(label)))&
-            stop'create_box(): Label must be specified if exapnder=.true.'
+            call terminate('create_box(): Label must be specified if exapnder=.true.')
     endif
 
     c_scroll = 0
@@ -760,7 +761,7 @@ contains
     if(present(expander))then
        if(expander)c_expand=1
        if(expander.and.(.not.present(label)))&
-            stop'create_box(): Label must be specified if exapnder=.true.'
+            call terminate('create_box(): Label must be specified if exapnder=.true.')
     endif
 
     c_scroll = 0
@@ -819,13 +820,11 @@ contains
     character(len=*), optional :: label, image
     
     if((.not.present(image)).and.(.not.present(label)))then
-       write(0,*)"gui_create_button(): button must have a label or an image!"
-       stop
+       call terminate("gui_create_button(): button must have a label or an image!")
     endif
 
     if(present(image).and.present(label))then
-       write(0,*)"gui_create_button(): button must have a label OR an image!"
-       stop
+       call terminate("gui_create_button(): button must have a label OR an image!")
     endif
     
     if(present(label))then
@@ -1194,8 +1193,7 @@ contains
     else if(orientation%id.eq.gui_vertical%id)then
        slider%is_vslider = 1
     else
-       write(0,*)"gui_create_slider(): Unrecognised orientation for slider:"
-       stop
+       call terminate("gui_create_slider(): Unrecognised orientation for slider:")
     end if
 
     c_draw = 0
@@ -1242,8 +1240,7 @@ contains
     else if(orientation%id.eq.gui_vertical%id)then
        slider%is_vslider = 1
     else
-       write(0,*)"gui_create_slider(): Unrecognised orientation for slider:"
-       stop
+       call terminate("gui_create_slider(): Unrecognised orientation for slider:")
     end if
 
     c_draw = 0
@@ -1375,8 +1372,7 @@ contains
     case("error")
        itype = 3
     case default
-       write(0,*)'gui_display_dialog(): unrecognised type '//trim(type)
-       stop
+       call terminate('gui_display_dialog(): unrecognised type '//trim(type))
     end select
 
     call createdialog(window%ptr,itype,trim(text)//char(0),ires)
@@ -1451,8 +1447,7 @@ contains
     character(len=*)  :: text
 
     if(.not.window%has_statusbar)then
-       write(0,*)'gui_window_set_statusbar(): window has no statusbar!'
-       stop
+       call terminate('gui_window_set_statusbar(): window has no statusbar!')
     endif
 
     call setstatusbar(window%statusbar, trim(text)//char(0), window%contextid)
@@ -1473,8 +1468,7 @@ contains
     integer(kind=C_INT) :: c_right
 
     if(.not.window%has_menubar)then
-       write(0,*)'gui_create_menu: window has no menubar!'
-       stop
+       call terminate('gui_create_menu: window has no menubar!')
     endif
 
     c_right = 0
@@ -1562,9 +1556,7 @@ contains
     endif
 
     if(menuitem%is_checkbox.and.menuitem%is_radiobutton)then
-       write(0,*)&
-            "gui_create_menu_item(): item cannot be checkbox AND radiobutton!"
-       stop
+       call terminate("gui_create_menu_item(): item cannot be checkbox AND radiobutton!")
     endif
 
     call createmenuitem(menuitem%ptr, menuitem%clicked, &
@@ -1605,9 +1597,8 @@ contains
     type (gui_menu_item) :: menuitem
 
     if(.not.(menuitem%is_checkbox.or.menuitem%is_radiobutton))then
-       write(0,*)'gui_menu_item_changed():'&
-            //' only available for checkbox and radiobutton menu items!'
-       stop
+       call terminate('gui_menu_item_changed():'&
+            //' only available for checkbox and radiobutton menu items!')
     endif
 
     if(menuitem%changed.ne.0)then
@@ -1632,9 +1623,8 @@ contains
     integer(kind=C_INT) :: c_checked
 
     if(.not.(menuitem%is_checkbox.or.menuitem%is_radiobutton))then
-       write(0,*)'gui_menu_item_changed():'&
-            //' only available for checkbox and radiobutton menu items!'
-       stop
+       call terminate('gui_menu_item_changed():'&
+            //' only available for checkbox and radiobutton menu items!')
     endif
 
     call menuitemstate(menuitem%ptr, c_checked)
@@ -1659,9 +1649,8 @@ contains
     integer(kind=C_INT) :: c_checked
 
     if(.not.(menuitem%is_checkbox.or.menuitem%is_radiobutton))then
-       write(0,*)'gui_menu_item_changed():'&
-            //' only available for checkbox and radiobutton menu items!'
-       stop
+       call terminate('gui_menu_item_changed():'&
+            //' only available for checkbox and radiobutton menu items!')
     endif
 
     if(checked)then
@@ -1697,9 +1686,7 @@ contains
             radiobutton%changed)
     else
        if(previous%has_next)then
-          write(0,*) &
-               'gui_create_radio_button(): buttons must be linked in a chain'
-          stop
+          call terminate('gui_create_radio_button(): buttons must be linked in a chain')
        endif
        call addradiobutton(radiobutton%ptr,box%ptr,trim(label)//char(0), &
             previous%ptr,radiobutton%changed)
@@ -1956,8 +1943,8 @@ contains
     if(present(height))then
        c_height = height
     endif
-    if(present(width).neqv.present(height))stop &
-         'Must specify width AND height in create_drawing_area'
+    if(present(width).neqv.present(height)) &
+         call terminate('Must specify width AND height in create_drawing_area')
 
     db = 0
     if(present(double_buffered))then
@@ -2024,9 +2011,8 @@ contains
     integer :: button
 
     if(button.lt.1.or.button.gt.5)then
-       write(0,*)"gui_drawing_area_mouse_clicked(): "//&
-            "button index must be in range 1-5"
-       stop
+       call terminate("gui_drawing_area_mouse_clicked(): "//&
+            "button index must be in range 1-5")
     endif
 
     if(drawingarea%mouse_state(3+button).gt.0)then
@@ -2049,9 +2035,8 @@ contains
     integer :: button
 
     if(button.lt.1.or.button.gt.5)then
-       write(0,*)"gui_drawing_area_mouse_down(): "//&
-            "button index must be in range 1-5"
-       stop
+       call terminate("gui_drawing_area_mouse_down(): "//&
+            "button index must be in range 1-5")
     endif
 
     if(drawingarea%mouse_state(8+button).gt.0)then

--- a/f90_util/src/Makefile.am
+++ b/f90_util/src/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = libf90_util.la
 
 @ax_mod_deps_f90_util@
 
-libf90_util_la_SOURCES = swap_endian.c c_to_fortran.c glob.c getcurrentdir.c file_parser.c write_png.c binary_io.c c_types.F90 key_file.F90 get_arguments.F90 f90_util.F90 byteswap.f90
+libf90_util_la_SOURCES = swap_endian.c c_to_fortran.c glob.c getcurrentdir.c file_parser.c write_png.c binary_io.c c_types.F90 terminate.f90 key_file.F90 get_arguments.F90 f90_util.F90 byteswap.f90
 libf90_util_la_LIBADD = @LIBPNG_LIBS@ @GLIB_LIBS@
 
 noinst_HEADERS = c_to_fortran.h

--- a/f90_util/src/Makefile.am
+++ b/f90_util/src/Makefile.am
@@ -5,7 +5,7 @@ lib_LTLIBRARIES = libf90_util.la
 
 @ax_mod_deps_f90_util@
 
-libf90_util_la_SOURCES = swap_endian.c c_to_fortran.c glob.c getcurrentdir.c file_parser.c write_png.c binary_io.c c_types.F90 terminate.f90 key_file.F90 get_arguments.F90 f90_util.F90 byteswap.f90
+libf90_util_la_SOURCES = terminate_c.c swap_endian.c c_to_fortran.c glob.c getcurrentdir.c file_parser.c write_png.c binary_io.c c_types.F90 terminate.f90 key_file.F90 get_arguments.F90 f90_util.F90 byteswap.f90
 libf90_util_la_LIBADD = @LIBPNG_LIBS@ @GLIB_LIBS@
 
 noinst_HEADERS = c_to_fortran.h

--- a/f90_util/src/f90_util.F90
+++ b/f90_util/src/f90_util.F90
@@ -7,6 +7,7 @@ module f90_util
 
   use c_types
   use get_argumentsmod
+  use terminate_module
 
   implicit none
   integer, parameter :: fname_maxlen=500

--- a/f90_util/src/get_arguments.F90
+++ b/f90_util/src/get_arguments.F90
@@ -4,6 +4,8 @@ module get_argumentsmod
   ! returns the i'th command line argument n variable x. x can be
   ! real, integer, double precision, string or logical.
   !
+  use terminate_module
+
   implicit none
 #include "../../config.h" 
   character(LEN=500) :: usage
@@ -93,7 +95,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     call get_arg(iarg,str)
@@ -107,7 +109,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     return
@@ -132,7 +134,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     call get_arg(iarg,str)
@@ -146,7 +148,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     return
@@ -171,7 +173,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     call get_arg(iarg,str)
@@ -186,7 +188,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     return
@@ -211,7 +213,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     call get_arg(iarg,str)
@@ -226,7 +228,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     return
@@ -249,7 +251,7 @@ contains
           write(*,*)'Usage: ',trim(usage)
           write(*,*)''
        end if
-       stop
+       call terminate()
     end if
 
     call get_arg(iarg,str)

--- a/f90_util/src/terminate.f90
+++ b/f90_util/src/terminate.f90
@@ -1,5 +1,6 @@
 module terminate_module
 
+  use c_types
   implicit none
 
 contains
@@ -12,7 +13,7 @@ contains
     if(present(message))then
        write(0,*)trim(message)
     endif
-    call cterminate(0)
+    call cterminate(int(0, kind=C_INT))
 
     return
   end subroutine terminate

--- a/f90_util/src/terminate.f90
+++ b/f90_util/src/terminate.f90
@@ -12,7 +12,7 @@ contains
     if(present(message))then
        write(0,*)trim(message)
     endif
-    stop 1
+    call cterminate(0)
 
     return
   end subroutine terminate

--- a/f90_util/src/terminate.f90
+++ b/f90_util/src/terminate.f90
@@ -1,0 +1,20 @@
+module terminate_module
+
+  implicit none
+
+contains
+  
+  subroutine terminate(message)
+    
+    implicit none
+    character(len=*), intent(in), optional :: message
+    
+    if(present(message))then
+       write(0,*)trim(message)
+    endif
+    stop 1
+
+    return
+  end subroutine terminate
+
+end module terminate_module

--- a/f90_util/src/terminate_c.c
+++ b/f90_util/src/terminate_c.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include "../../config.h"
+
+#define CTERMINATE_F90  FC_FUNC (cterminate,  CTERMINATE)
+
+void CTERMINATE_F90(int *ret)
+{
+    exit(*ret);
+    return;
+}
+

--- a/main/src/additional_data.F90
+++ b/main/src/additional_data.F90
@@ -570,7 +570,7 @@ contains
 #ifdef HAVE_HDF5
          call additional_data_hdf5(i,j)
 #else
-         stop'Code was compiled without HDF5 support'
+         call terminate('Code was compiled without HDF5 support')
 #endif
       case("BINARY")
          aux_file(i:j)%ok        = .false.
@@ -869,7 +869,7 @@ contains
        case("REAL")
           allocate(rprop(iaux)%ptr(np(ispecies)), stat=istat)
        case default
-          stop'Unknown property type in additional_data_ascii()'
+          call terminate('Unknown property type in additional_data_ascii()')
        end select
        if(istat.ne.0)exit
     end do
@@ -946,7 +946,7 @@ contains
                    case("REAL")
                       read(col,*,iostat=ios)rprop(icol(jcol))%ptr(nread)
                    case default
-                      stop'Unknown data type in additional_data_ascii'
+                      call terminate('Unknown data type in additional_data_ascii')
                    end select
                    if(ios.ne.0)then
                       aux_file(i:j)%ok     = .false.

--- a/main/src/catalogue_data.f90
+++ b/main/src/catalogue_data.f90
@@ -710,7 +710,7 @@ contains
     real(kind=pos_kind), dimension(:),   pointer       :: radius
     character(len=label_length), dimension(:), pointer :: label
 
-    if(icat.gt.ncatalogue)stop'icat out of range in catalogue_data_get_points'
+    if(icat.gt.ncatalogue)call terminate('icat out of range in catalogue_data_get_points')
     
     npoints =  catalogue(icat)%npoints
     pos     => catalogue(icat)%pos

--- a/main/src/colour_table.f90
+++ b/main/src/colour_table.f90
@@ -161,7 +161,7 @@ contains
     endif
 
     ! Make a new colour table using the input data
-    if(itab.gt.ncoltabmax)stop'Too many colour tables! Increase ncoltabmax'
+    if(itab.gt.ncoltabmax)call terminate('Too many colour tables! Increase ncoltabmax')
 
     ! Record name of the new colour table
     coltab(itab)%name = trim(name)
@@ -240,7 +240,7 @@ contains
        ! Linear interpolation
        do i = 1, ubound(idx,1)-lbound(idx,1), 1
           do j = idx(i), idx(i+1), 1
-             if(j.lt.0.or.j.gt.255)stop'colour_table_add() - idx out of range'
+             if(j.lt.0.or.j.gt.255)call terminate('colour_table_add() - idx out of range')
              f = real(j-idx(i))/(idx(i+1)-idx(i))
              r_out(j) = floor(r(i) + f*(r(i+1)-r(i)))
              g_out(j) = floor(g(i) + f*(g(i+1)-g(i)))

--- a/main/src/command_line.f90
+++ b/main/src/command_line.f90
@@ -74,8 +74,7 @@ contains
           rinfo%do_sphere = .true.
           call extract_params(arg, params(1:4), iostat)
           if(iostat.ne.0)then
-             write(0,*)"Unable to interpret region specification!"
-             stop
+             call terminate("Unable to interpret region specification!")
           else
              rinfo%pos    = params(1:3)
              rinfo%radius = params(4)
@@ -85,8 +84,7 @@ contains
           rinfo%do_sampling = .true.
           call extract_params(arg, params(1:1), iostat)
           if(iostat.ne.0)then
-             write(0,*)"Unable to interpret sampling rate as real!"
-             stop
+             call terminate("Unable to interpret sampling rate as real!")
           else
              rinfo%sample_rate = params(1)
           endif
@@ -107,7 +105,7 @@ contains
           write(0,*)"If the --movie flag is specified then a snapshot file"
           write(0,*)"must be specified."
           write(0,*)""
-          stop
+          call terminate()
        endif
        if(len_trim(selection_file).gt.0)then
           write(0,*)""
@@ -129,7 +127,7 @@ contains
        write(0,*)""
        write(0,*)"The --movie and --config flags must not both be specified"
        write(0,*)""
-       stop
+       call terminate()
     endif
 
     ! Help text
@@ -162,8 +160,7 @@ contains
        write(0,*)"The configuration file for the --movie option can be created"
        write(0,*)"with the 'Save movie parameters' button in the movie window."
        write(0,*)""
-
-       stop
+       call terminate()
     endif
 
     return

--- a/main/src/data_array.f90
+++ b/main/src/data_array.f90
@@ -175,7 +175,7 @@ contains
     else if(type.eq.REAL82D)then
        allocate(new_block%r8ptr2d(width,blocksize), stat=istat)
     else
-       stop'new_block() - Invalid data type'
+       call terminate('new_block() - Invalid data type')
     endif
 
     if(istat.ne.0)nullify(new_block)
@@ -258,8 +258,7 @@ contains
        darray%type = this_type
        darray%width = 1
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")
     endif
 
     ! Add the data
@@ -381,8 +380,7 @@ contains
        darray%type = this_type
        darray%width = 1
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")
     endif
 
     ! Add the data
@@ -504,8 +502,7 @@ contains
        darray%type = this_type
        darray%width = 1
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")
     endif
 
     ! Add the data
@@ -627,8 +624,7 @@ contains
        darray%type = this_type
        darray%width = 1
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")
     endif
 
     ! Add the data
@@ -751,8 +747,7 @@ contains
        darray%type = this_type
        darray%width = size(data,1)
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")
     endif
 
     ! Add the data
@@ -874,8 +869,7 @@ contains
        darray%type = this_type
        darray%width = size(data,1)
     else if(darray%type.ne.this_type)then
-       write(0,*)"data_array_add_elements() - inconsistent types!"
-       stop
+       call terminate("data_array_add_elements() - inconsistent types!")       
     endif
 
     ! Add the data

--- a/main/src/fancyplot.F90
+++ b/main/src/fancyplot.F90
@@ -718,7 +718,7 @@ contains
           w = 0.0
        endif
     case default
-       stop'Invalid value of ikernel'
+       call terminate('Invalid value of ikernel')
     end select
 
     kernel = w

--- a/main/src/file_units.f90
+++ b/main/src/file_units.f90
@@ -5,6 +5,8 @@ module file_units
 ! It tries unit numbers from 100 upwards and returns the first free unit.
 ! It aborts if it runs out of valid unit numbers.
 !
+  use f90_util
+
 contains
 
   integer function get_unit()
@@ -22,8 +24,7 @@ contains
     end do
     
     if(.not.exists)then
-       write(*,*)'Error in get_unit(): ran out of valid unit numbers!'
-       stop
+       call terminate('Error in get_unit(): ran out of valid unit numbers!')
     end if
     
     get_unit = i

--- a/main/src/gadget_eagle_reader.F90
+++ b/main/src/gadget_eagle_reader.F90
@@ -18,6 +18,7 @@ module gadget_eagle_reader
   use key_file
   use partial_read_info
   use array_shrinker
+  use f90_util
 
   implicit none
   private
@@ -320,7 +321,7 @@ contains
 #else
     ! Should never get here because menu option is greyed out if HDF5 not
     ! available
-    stop'gadget_eagle_reader - Code was compiled without HDF5 support'
+    call terminate('gadget_eagle_reader - Code was compiled without HDF5 support')
 
     ! Stop compiler complaining about return value not being set
     gadget_eagle_open%success = .false.
@@ -822,7 +823,7 @@ contains
 #else
     ! Should never get here because menu option is greyed out if HDF5 not
     ! available
-    stop'gadget_eagle_reader - Code was compiled without HDF5 support'
+    call terminate('gadget_eagle_reader - Code was compiled without HDF5 support')
 
     ! Stop compiler complaining about return value not being set
     gadget_eagle_read%success = .false.

--- a/main/src/gadget_hdf5_reader.F90
+++ b/main/src/gadget_hdf5_reader.F90
@@ -18,6 +18,7 @@ module gadget_hdf5_reader
   use key_file
   use partial_read_info
   use array_shrinker
+  use f90_util
 
   implicit none
   private
@@ -283,7 +284,7 @@ contains
 #else
     ! Should never get here because menu option is greyed out if HDF5 not
     ! available
-    stop'gadget_hdf5_reader - Code was compiled without HDF5 support'
+    call terminate('gadget_hdf5_reader - Code was compiled without HDF5 support')
 
     ! Stop compiler complaining about return value not being set
     gadget_hdf5_open%success = .false.
@@ -853,7 +854,7 @@ contains
 #else
     ! Should never get here because menu option is greyed out if HDF5 not
     ! available
-    stop'gadget_hdf5_reader - Code was compiled without HDF5 support'
+    call terminate('gadget_hdf5_reader - Code was compiled without HDF5 support')
 
     ! Stop compiler complaining about return value not being set
     gadget_hdf5_read%success = .false.

--- a/main/src/gadgetviewer.F90
+++ b/main/src/gadgetviewer.F90
@@ -60,12 +60,12 @@ program gadgetviewer
         if(.not.res%success)then
            write(0,*)'Failed to read file '//trim(snapshot_file)//":"
            write(0,*)trim(res%string)
-           stop
+           call terminate()
         endif
      else
         write(0,*)'Failed to read file '//trim(snapshot_file)//":"
         write(0,*)trim(res%string)
-        stop
+        call terminate()
      endif
   endif
   if(.not.batch_mode)call read_partial_set_filename(snapshot_file,&
@@ -85,7 +85,7 @@ program gadgetviewer
      res = load_settings(config_file)
      if(.not.res%success)then
         write(0,*)"Unable to read configuration file ",trim(config_file)
-        stop
+        call terminate()
      endif
   endif
   
@@ -94,12 +94,12 @@ program gadgetviewer
      res = selection_restore_state(selection_file)
      if(.not.res%success)then
         write(0,*)"Unable to read selected particles: ",trim(selection_file)
-        stop
+        call terminate()
      else
         res = selection_apply_all(psample)
         if(.not.res%success)then
            write(0,*)"Unable to apply selection: ",trim(res%string)
-           stop
+           call terminate()
         endif
      endif
   endif
@@ -121,7 +121,7 @@ program gadgetviewer
      if(.not.res%success)then
         write(0,*)"Error while making movie: "
         write(0,*)trim(res%string)
-        stop
+        call terminate()
      endif
   endif
 

--- a/main/src/graph.F90
+++ b/main/src/graph.F90
@@ -352,8 +352,8 @@ contains
                gui_file_save, ok, fname)
           if(ok)then
              ! Image should already have been generated
-             if(.not.associated(image))stop &
-                  'Image not allocated when writing out screenshot'
+             if(.not.associated(image))call terminate( &
+                  'Image not allocated when writing out screenshot')
              if(write_png(fname,width,height,image))then
                 ! Success
                 bt=gui_display_dialog(window,"info", &

--- a/main/src/main_window.F90
+++ b/main/src/main_window.F90
@@ -350,8 +350,7 @@ contains
     call gadget_groups_format_list(ngroupformat)
     allocate(groupformat(ngroupformat), groupformat_item(ngroupformat), stat=istat)
     if(istat.ne.0)then
-       write(0,*)"Unable to allocate memory"
-       stop
+       call terminate("Unable to allocate memory")
     endif
     call gadget_groups_format_list(ngroupformat, groupformat)
     do i = 1, ngroupformat, 1
@@ -464,8 +463,7 @@ contains
     call gui_menu_item_set_state(view_show_selection, overlay_show_selection)
     allocate(show_selection(size(display_selection)), stat=istat)
     if(istat.ne.0)then
-       write(0,*)"Unable to allocate memory"
-       stop
+       call terminate("Unable to allocate memory")
     end if
     do i = 1, size(display_selection), 1
        call gui_create_menu_item(show_selection(i), view_show_selection_menu, &

--- a/main/src/octree.F90
+++ b/main/src/octree.F90
@@ -14,6 +14,7 @@ module octreemod
   use sort
   use data_types
   use random_shuffle
+  use f90_util
 
   implicit none
   private 
@@ -259,8 +260,7 @@ contains
        if(present(stat))then
           return
        else
-          write(0,*)"Insufficient memory to build tree"
-          stop
+          call terminate("Insufficient memory to build tree")
        endif
     endif
 
@@ -294,8 +294,7 @@ contains
           call deallocate_octree(tree)
           return
        else
-          write(0,*)"Insufficient memory to build tree"
-          stop
+          call terminate("Insufficient memory to build tree")
        endif
     endif
     tree%list(np)=-1
@@ -324,8 +323,7 @@ contains
           call deallocate_octree(tree)
           return
        else
-          write(0,*)"Insufficient memory to build tree"
-          stop
+          call terminate("Insufficient memory to build tree")
        endif
     endif
 
@@ -338,7 +336,7 @@ contains
              if(node%np.gt.1)then
                 ! Get number of particles in this node
                 n = node%np
-                if(n.gt.nmax)stop'nmax too small!'
+                if(n.gt.nmax)call terminate('nmax too small!')
                 ! Make array to access particles in random order
                 call shuffle(idx(1:n))
                 ! Get indexes of particles in this node
@@ -407,8 +405,7 @@ contains
                      call deallocate_octree(tree)
                      return
                   else
-                     write(0,*)"Insufficient memory to build tree"
-                     stop
+                     call terminate("Insufficient memory to build tree")
                   endif
                endif
                child_node%head=i
@@ -485,7 +482,7 @@ contains
     type (nodetype), pointer :: node, child_node
 
     if(.not.associated(tree%first_node)) &
-         call panic("range_search(): Tree has not been built yet!")
+         call terminate("range_search(): Tree has not been built yet!")
     
     nout=0
     node => tree%first_node
@@ -597,7 +594,7 @@ contains
 
     ! Check tree has been built
     if(.not.associated(tree%first_node)) &
-         call panic('radius_search(): Tree has not been built yet!')
+         call terminate('radius_search(): Tree has not been built yet!')
 
     nout=0
     node => tree%first_node
@@ -691,7 +688,7 @@ contains
                       if(ipart.ge.1.and.ipart.le.size(tree%list))then
                          ipart=tree%list(ipart)
                       else
-                         stop'ipart out of range'
+                         call terminate('ipart out of range')
                       endif
                       !write(0,*)"G"
                    end do
@@ -773,7 +770,7 @@ contains
 
     ! Check tree has been built
     if(.not.associated(tree%first_node)) &
-         call panic('periodic_radius_search(): Tree has not been built yet!')
+         call terminate('periodic_radius_search(): Tree has not been built yet!')
 
     ! Ensure requested centre is in the box
     wrap_centre = centre
@@ -887,7 +884,7 @@ contains
                       if(ipart.ge.1.and.ipart.le.size(tree%list))then
                          ipart=tree%list(ipart)
                       else
-                         stop'ipart out of range'
+                         call terminate('ipart out of range')
                       endif
                       !write(0,*)"G"
                    end do
@@ -997,20 +994,6 @@ contains
 
     return
   end subroutine deallocate_octree
-!
-! ------------------------------------------------------------------
-!
-
-  subroutine panic(message)
-
-    implicit none
-    character(len=*) :: message
-
-    write(0,*)trim(message)
-    stop
-
-    return
-  end subroutine panic
 
 !
 ! ------------------------------------------------------------------
@@ -1039,7 +1022,7 @@ contains
     integer :: ilevmax
 
     if(.not.associated(tree%first_node)) &
-         call panic('open_leaf_node(): Tree has not been built yet!')
+         call terminate('open_leaf_node(): Tree has not been built yet!')
     
     nout=0
     node => tree%first_node
@@ -1163,7 +1146,7 @@ contains
 #endif
 
     if(.not.associated(tree%first_node)) &
-         call panic('open_leaf_node(): Tree has not been built yet!')
+         call terminate('open_leaf_node(): Tree has not been built yet!')
 
     call open_leaf_node(tree,centre,nout,tree%idx(:,myid),rnodemin,rnodemax,rmin)
     if(nout.gt.0)then

--- a/main/src/percentiles.f90
+++ b/main/src/percentiles.f90
@@ -4,6 +4,7 @@ module percentiles
 !
   use sort
   use data_types
+  use f90_util
 
   implicit none
   private
@@ -36,7 +37,7 @@ contains
 
     if(n.eq.0)then
        ! Zero points - can't do anything
-       stop'Cannot calculate percentile for zero data points!'
+       call terminate('Cannot calculate percentile for zero data points!')
     else if(n.eq.1)then
        ! One point - just return that data point
        percentile_real4 = data(1)
@@ -55,7 +56,7 @@ contains
           r_lower  = data(idx(ilower))
           r_higher = data(idx(ihigher))
           f = ((p*(n-1.0))-real(ilower-1.0))
-          if(f.lt.0.0.or.f.gt.1.0)stop'f out of range'
+          if(f.lt.0.0.or.f.gt.1.0)call terminate('f out of range')
           percentile_real4 = (f*r_higher) + ((1-f)*r_lower)
        endif
     endif
@@ -84,7 +85,7 @@ contains
 
     if(n.eq.0)then
        ! Zero points - can't do anything
-       stop'Cannot calculate percentile for zero data points!'
+       call terminate('Cannot calculate percentile for zero data points!')
     else if(n.eq.1)then
        ! One point - just return that data point
        percentile_real8 = data(1)
@@ -103,7 +104,7 @@ contains
           r_lower  = data(idx(ilower))
           r_higher = data(idx(ihigher))
           f = ((p*(n-1.0))-real(ilower-1.0))
-          if(f.lt.0.0.or.f.gt.1.0)stop'f out of range'
+          if(f.lt.0.0.or.f.gt.1.0)call terminate('f out of range')
           percentile_real8 = (f*r_higher) + ((1-f)*r_lower)
        endif
     endif

--- a/main/src/plotter.f90
+++ b/main/src/plotter.f90
@@ -68,7 +68,7 @@ contains
 
     call plotter_settings_close()
 
-    if(i.lt.1.or.i.gt.nplottypes)stop'Plot type index out of range!'
+    if(i.lt.1.or.i.gt.nplottypes)call terminate('Plot type index out of range!')
 
     iplotter = i
 
@@ -160,7 +160,7 @@ contains
        case(5)
           call smoothed_property_plot_make_image(nx, ny, trans, buf, show_species)
        case default
-          stop'Invalid plot type index in plotter_make_image()'
+          call terminate('Invalid plot type index in plotter_make_image()')
        end select
        ! Add an 'overlay' to the image with any annotations we want
        call overlay_add_to_image(nx, ny, trans, buf, show_species)
@@ -216,7 +216,7 @@ contains
     case(5)
        call smoothed_property_plot_settings_open(mainwin,settings_window,last_type_selected)
     case default
-       stop'Invalid plot type index in plotter_make_image()'
+       call terminate('Invalid plot type index in plotter_make_image()')
     end select
 
     ! Move the settings window to the LHS of the main window -
@@ -278,7 +278,7 @@ contains
     case(5)
        res = smoothed_property_plot_process_events()
     case default
-       stop'Invalid plot type index in plotter_make_image()'
+       call terminate('Invalid plot type index in plotter_make_image()')
     end select
 
     plotter_process_events = res
@@ -310,7 +310,7 @@ contains
     case(5)
        call smoothed_property_plot_update_settings()
     case default
-       stop'Invalid plot type index in plotter_update_settings()'
+       call terminate('Invalid plot type index in plotter_update_settings()')
     end select
 
     return

--- a/main/src/progress_bar.f90
+++ b/main/src/progress_bar.f90
@@ -113,7 +113,7 @@ contains
 
     if(.not.display_progress_bar)return
 
-    if(.not.window_open)stop'Progress bar window not open!'
+    if(.not.window_open)call terminate('Progress bar window not open!')
 
     if(nesting_level.ne.1)then
        ! Nested calls to the progress bar module will redraw
@@ -126,7 +126,7 @@ contains
     endif
 
     if(gui_window_closed(main_window))then
-       stop
+       call terminate()
     endif
 
     return
@@ -142,7 +142,7 @@ contains
 
     if(.not.display_progress_bar)return
 
-    if(.not.window_open)stop'Progress bar window not open!'
+    if(.not.window_open)call terminate('Progress bar window not open!')
 
     nesting_level = nesting_level - 1
     if(nesting_level.gt.0)return

--- a/main/src/property_plot.f90
+++ b/main/src/property_plot.f90
@@ -496,7 +496,7 @@ contains
                 ! Next particle
              end do
           case default
-             stop'Unrecognised data type in property_plot_make_image()'
+             call terminate('Unrecognised data type in property_plot_make_image()')
           end select
 
        endif

--- a/main/src/read_gadget_groups.f90
+++ b/main/src/read_gadget_groups.f90
@@ -668,7 +668,7 @@ contains
 
     if(present(format_names))then
        if(size(format_names).lt.nformat) &
-            stop'format_names array too small in gadget_groups'
+            call terminate('format_names array too small in gadget_groups')
        do i = 1, nformat, 1
           format_names(i) = trim(group_format(i)%name)
        end do

--- a/main/src/selection.F90
+++ b/main/src/selection.F90
@@ -210,7 +210,7 @@ contains
     call particle_store_contents(pdata, get_nspecies=nspecies)
 
     if(sel%nspecies.ne.nspecies) &
-         stop'selection_apply(): nspecies incorrect'
+         call terminate('selection_apply(): nspecies incorrect')
     
     ! Bitmask for this selection
     mask    = ibset(0, isel)
@@ -331,7 +331,7 @@ contains
           call particle_store_property(pdata, ispecies, iprop, get_rdata=rdata)
           nullify(idata)
        case default
-          stop'selection_find_particles() - unrecognised property type'
+          call terminate('selection_find_particles() - unrecognised property type')
        end select
     else
        nullify(rdata,idata)
@@ -476,8 +476,8 @@ contains
     integer, optional :: ispecies
     integer :: status
 
-    if(sel1%nspecies.ne.sel2%nspecies)stop &
-         'Number of species in selection doesnt match'
+    if(sel1%nspecies.ne.sel2%nspecies)call terminate( &
+         'Number of species in selection doesnt match')
     
     sel1%empty = .true.
 
@@ -588,8 +588,8 @@ contains
 
     status = 0
 
-    if(sel1%nspecies.ne.sel2%nspecies)stop &
-         'Number of species in selection doesnt match'
+    if(sel1%nspecies.ne.sel2%nspecies)call terminate( &
+         'Number of species in selection doesnt match')
     
     sel1%empty = .true.
 

--- a/main/src/smoothed_property_plot.F90
+++ b/main/src/smoothed_property_plot.F90
@@ -1089,7 +1089,7 @@ contains
           w = 0.0
        endif
     case default
-       stop'Invalid value of ikernel'
+       call terminate('Invalid value of ikernel')
     end select
 
     kernel = w

--- a/main/src/snapshot_reader.f90
+++ b/main/src/snapshot_reader.f90
@@ -23,6 +23,7 @@ module snapshot_reader
   use plotter
   use info_window
   use partial_read_info
+  use f90_util
 
   implicit none
   save
@@ -63,7 +64,7 @@ contains
     character(len=*) :: str
 
     snapformat = trim(str)
-    if(.not.(any(format_names.eq.str)))stop"Unrecognised snapshot format!"
+    if(.not.(any(format_names.eq.str)))call terminate("Unrecognised snapshot format!")
 
     return
   end subroutine snapshot_set_format
@@ -101,7 +102,7 @@ contains
     case("DUMMY")
        res = dummy_open(fname,isnap,ri_in)
     case default
-       stop"Unrecognised snapshot format!"
+       call terminate("Unrecognised snapshot format!")
     end select
      
     if(res%success)then
@@ -153,7 +154,7 @@ contains
        call summary_add_line(s,"Simulation format: DUMMY!")
        res = dummy_read(isnap, rinfo)
     case default
-       stop"Unrecognised snapshot format!"
+       call terminate("Unrecognised snapshot format!")
     end select
 
     call progress_bar_close()

--- a/main/src/sort.F90
+++ b/main/src/sort.F90
@@ -5,6 +5,8 @@ module sort
 ! Uses heap sort for large arrays and shell sort for small arrays.
 !
   use data_types
+  use f90_util
+
   implicit none
   private
 
@@ -538,7 +540,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -654,7 +656,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -770,7 +772,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -886,7 +888,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1006,7 +1008,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1127,7 +1129,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1243,7 +1245,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1359,7 +1361,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1475,7 +1477,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1595,7 +1597,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
     ! If we have 0 or 1 elements, no sorting required!
     if(n.eq.0)return
@@ -1726,7 +1728,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -1823,7 +1825,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -1920,7 +1922,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2020,7 +2022,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2117,7 +2119,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2218,7 +2220,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2315,7 +2317,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2412,7 +2414,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2512,7 +2514,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays
@@ -2609,7 +2611,7 @@ contains
 
     ! Check array sizes
     n = size(arr)
-    if(size(idx).lt.n)stop'sort_index(): Index array is too small!'
+    if(size(idx).lt.n)call terminate('sort_index(): Index array is too small!')
 
 #ifdef _OPENMP
     ! Use serial sort for small arrays


### PR DESCRIPTION
In various places the code contained stop statements with an error message and no space between the stop and the message. This prevented compilation with gfortran 8. Also, it's not clear that stop with a string message is strictly allowed by the language standard.  This PR replaces the stops with calls to a new terminate() function.
