### PR TITLE
Use library flags in Automake check for Glib config file parser

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,10 +62,13 @@ GV_FIND_LIBRARY([hdf5],  [HDF5],  [hdf5],   [hdf5],   [H5open])
 
 # Check if GLib has the config file parser
 have_keyfile="no"
+TMP_LDFLAGS=$LDFLAGS
+LDFLAGS="${LDFLAGS} "-L${GV_GLIB_PATH}/lib/
 AC_CHECK_LIB(glib-2.0, g_key_file_new, [have_keyfile="yes"], [], [])
 if test "${have_keyfile}" == "yes" ; then
   AC_DEFINE([HAVE_KEYFILE],[],[Defined if we have GLib config file parser])
 fi
+LDFLAGS=$TMP_LDFLAGS
 
 # Only build hdf5 wrapper library if we have HDF5
 AM_CONDITIONAL([COND_HDF5], [test "$USE_HDF5" = yes])


### PR DESCRIPTION
This is a tiny fix to the configure script so that if you use --with-libglib-2.0 to specify a path to Glib, that path is used when the separate test for the config file parser is done.

Otherwise, if Glib is installed somewhere non-standard (e.g. homebrew on Mac) the config parser won't be found even if it is actually available and so the automatic reading of extra datasets silently fails.