### PR TITLE
Allow reading 6 byte particle IDs from Gadget-4

### DIFF
--- a/hdf5/src/read_hdf5_c.c
+++ b/hdf5/src/read_hdf5_c.c
@@ -296,6 +296,9 @@ void READATTRIB_F90(char *name, int *type, void *data, int *rank,
 
 /*
   Get type of a dataset
+
+  Integer types with 1-4 bytes are read as 4 byte integers.
+  Integer types with 5-8 bytes are read as 8 byte integers.
 */
 #define DATASETTYPE_F90 FC_FUNC (datasettype, DATASETTYPE)
 void DATASETTYPE_F90(char *name, int *type, int *iostat)
@@ -319,9 +322,15 @@ void DATASETTYPE_F90(char *name, int *type, int *iostat)
     case H5T_INTEGER:
       switch(size)
 	{
+	case 1:
+	case 2:
+	case 3:
 	case 4:
 	  *type = 0;
 	  break;
+	case 5:
+	case 6:
+	case 7:
 	case 8:
 	  *type = 1;
 	  break;


### PR DESCRIPTION
This addresses #21 and allows reading of Gadget-4 snapshots with 6 byte particle IDs.

The function hdf5_dataset_type() is modified to report integer types of size 1-4 bytes as 4 byte integers and integer types of 5-8 bytes as 8 byte integers. This should cause HDF5 to convert the data to a type we can work with.