### PR TITLE
Add option to select particles of all types in select particles dialog

### DIFF
--- a/f90_util/src/f90_util.F90
+++ b/f90_util/src/f90_util.F90
@@ -476,9 +476,41 @@ contains
 
     ! Try to match to a file name
     call globfname(pattern, len(pattern))
-    
+
     return
   end subroutine glob
+
+  subroutine intersect(n1, arr1, n2, arr2)
+    !
+    ! Modify arr1 to contain just the intersection of arr1 and arr2.
+    ! Updates arr1 and n1.
+    !
+    implicit none
+    integer,          intent(inout) :: n1
+    character(len=*), dimension(:), intent(inout) :: arr1
+    integer,          intent(in) :: n2
+    character(len=*), dimension(:), intent(in) :: arr2
+    integer :: i1, i2, n
+    logical :: keep
+
+    n = 0
+    do i1 = 1, n1, 1
+       keep = .false.
+       do i2 = 1, n2, 1
+          if(arr1(i1).eq.arr2(i2))then
+             keep = .true.
+             exit
+          endif
+       end do
+       if(keep)then
+          n = n + 1
+          arr1(n) = arr1(i1)
+       endif
+    end do
+    n1 = n
+
+    return
+  end subroutine intersect
 
 end module f90_util
 

--- a/main/src/particle_store.F90
+++ b/main/src/particle_store.F90
@@ -56,10 +56,12 @@ module particle_store
   public :: particle_store_property       ! Get data for one property
   public :: particle_store_loaded         ! Determine if data is loaded
   public :: particle_store_get_time       ! Return the time of this snapshot
-
+  public :: particle_store_common_properties ! Get names of properties common to all particles
+  public :: particle_store_get_property_index ! Get the index of a property given its name
+  
   ! Build octrees used for fast random sampling
   public :: particle_store_build_trees
-  
+
   ! Get property values at some point in space
   public :: particle_store_evaluate_property
 
@@ -588,6 +590,42 @@ contains
   end subroutine particle_store_contents
 
 !
+! Return the names of properties which exist for all particle types with particles
+!
+  subroutine particle_store_common_properties(pdata, nprops, propnames)
+
+    implicit none
+    type (pdata_type) :: pdata
+    integer, intent(out) :: nprops
+    character(len=*), dimension(:), intent(out) :: propnames
+    logical :: found_particles
+    integer :: i
+    integer :: nprops_tmp
+    character(len=maxlen), dimension(maxprops) :: propnames_tmp
+    integer(kind=index_kind) :: np
+
+    found_particles = .false.
+    nprops = 0
+    do i = 1, pdata%nspecies, 1
+       call particle_store_species(pdata, i, get_nprops=nprops_tmp, &
+            get_propnames=propnames_tmp, get_np=np)
+       if(np.gt.0)then
+          if(.not.found_particles)then
+             ! This is the first type with >0 particles
+             propnames = propnames_tmp
+             nprops = nprops_tmp
+             found_particles = .true.
+          else
+             ! Only keep properties which exist for both types
+             call intersect(nprops, propnames, nprops_tmp, propnames_tmp)
+          endif
+       endif
+    end do
+
+    return
+  end subroutine particle_store_common_properties
+
+!
 ! This returns information about a particle species
 !
   subroutine particle_store_species(pdata, ispecies, get_name, get_np, &
@@ -747,7 +785,28 @@ contains
 
     return
   end subroutine particle_store_property
-  
+!
+! Given a property name, find its index (or -1 if not found)
+!
+  integer function particle_store_get_property_index(pdata, ispecies, name)
+
+    implicit none
+    type (pdata_type) :: pdata
+    character(len=*) :: name
+    integer :: ispecies
+    integer :: i
+
+    if(ispecies.ge.1.and.ispecies.le.pdata%nspecies)then
+       do i = 1, pdata%species(ispecies)%nprops, 1
+          if(pdata%species(ispecies)%property(i)%name.eq.name)then
+             particle_store_get_property_index = i
+          endif
+       end do
+    endif
+    particle_store_get_property_index = -1
+    return
+  end function particle_store_get_property_index
+
 !
 ! This does a consistency check on the particle data. It should not
 ! be called until all the data has been loaded.

--- a/main/src/particle_store.F90
+++ b/main/src/particle_store.F90
@@ -796,14 +796,16 @@ contains
     integer :: ispecies
     integer :: i
 
+    particle_store_get_property_index = -1
     if(ispecies.ge.1.and.ispecies.le.pdata%nspecies)then
        do i = 1, pdata%species(ispecies)%nprops, 1
           if(pdata%species(ispecies)%property(i)%name.eq.name)then
              particle_store_get_property_index = i
+             return
           endif
        end do
     endif
-    particle_store_get_property_index = -1
+
     return
   end function particle_store_get_property_index
 

--- a/main/src/selection.F90
+++ b/main/src/selection.F90
@@ -880,7 +880,8 @@ contains
     integer :: nprops_common
     character(len=maxlen), dimension(maxprops) :: propnames_common
     integer :: jspecies
-
+    integer(kind=index_kind) :: np
+    
     ! Return true if main window needs to be redrawn
     selection_process_events = .false.
 
@@ -1020,6 +1021,10 @@ contains
           ! Skip this type if not selected and we're not doing all types
           if(ispecies.ne.jspecies.and.ispecies.ne.nspecies+1)cycle
 
+          ! Skip this type if there are no particles
+          call particle_store_species(pdata, jspecies, get_np=np)
+          if(np.eq.0)cycle
+
           ! Determine index of particle property to select on
           call gui_combo_box_get_index(prop_box, iprop)
           if(jspecies.eq.nspecies+1)then
@@ -1030,7 +1035,7 @@ contains
           endif
 
           call particle_store_species(psample, jspecies, get_nprops=nprops)
-          if(iprop.gt.nprops.or.iprop.lt.1)return
+          if(iprop.gt.nprops.or.iprop.lt.1)cycle
           call gui_checkbox_get_state(radius_checkbox, use_radius)
           call gui_checkbox_get_state(prop_checkbox,   use_prop)
           if(use_prop)then

--- a/main/src/selection.F90
+++ b/main/src/selection.F90
@@ -881,6 +881,7 @@ contains
     character(len=maxlen), dimension(maxprops) :: propnames_common
     integer :: jspecies
     integer(kind=index_kind) :: np
+    integer :: jprop
     
     ! Return true if main window needs to be redrawn
     selection_process_events = .false.
@@ -1027,19 +1028,23 @@ contains
 
           ! Determine index of particle property to select on
           call gui_combo_box_get_index(prop_box, iprop)
-          if(jspecies.eq.nspecies+1)then
+          if(ispecies.eq.nspecies+1)then
              ! Doing all types, so combo box contains common properties only.
              ! Need to translate index.
              call particle_store_common_properties(pdata, nprops_common, propnames_common)
-             iprop = particle_store_get_property_index(pdata, jspecies, propnames_common(iprop))
+             jprop = particle_store_get_property_index(pdata, jspecies, propnames_common(iprop))
+          else
+             ! Doing one type, so no translation needed
+             jprop = iprop
           endif
 
           call particle_store_species(psample, jspecies, get_nprops=nprops)
-          if(iprop.gt.nprops.or.iprop.lt.1)cycle
+
+          if(jprop.gt.nprops.or.jprop.lt.1)cycle
           call gui_checkbox_get_state(radius_checkbox, use_radius)
           call gui_checkbox_get_state(prop_checkbox,   use_prop)
           if(use_prop)then
-             call particle_store_property(psample, jspecies, iprop, &
+             call particle_store_property(psample, jspecies, jprop, &
                   get_type=type)
              call gui_entrybox_get_text(val_min_entry, str)
              select case(type)
@@ -1100,11 +1105,11 @@ contains
           call selection_clear(sel_tmp, pdata)
           if(use_full)then
              res = selection_find_particles(sel_tmp, pdata, jspecies, &
-                  centre, radius, iprop, rval_min, rval_max, &
+                  centre, radius, jprop, rval_min, rval_max, &
                   ival_min, ival_max)
           else
              res = selection_find_particles(sel_tmp, psample, jspecies, &
-                  centre, radius, iprop, rval_min, rval_max, &
+                  centre, radius, jprop, rval_min, rval_max, &
                   ival_min, ival_max)
           endif
 


### PR DESCRIPTION
This allows selecting particles of any type which are within a specified radius of the selected point and/or have properties in a specified range. When selecting on particle properties, only properties which are present for all particle types can be used.

This should be useful for selecting all particles in a particular halo, for example.